### PR TITLE
pipeline2ATX: Use name instead of display name for log file name

### DIFF
--- a/vars/pipeline2ATX.groovy
+++ b/vars/pipeline2ATX.groovy
@@ -65,7 +65,7 @@ def call(log = false, jobName = '', int buildNumber = 0, def customAttributes = 
         error "Job ${jobName} with build number ${buildNumber} not found!"
     }
 
-    def filename = "${build.getParent().getDisplayName()}_${build.getNumber()}"
+    def filename = "${build.getParent().getName()}_${build.getNumber()}"
     def attributes = getBuildAttributes(build, customAttributes)
     def constants = getBuildConstants(build, customConstants)
     def executionSteps = getExecutionSteps(build, log)


### PR DESCRIPTION
The Jenkins github plugin now uses the pull request title as display name for pull request pipelines. This makes the pipeline2ATX var fail, if the title contains special characters like `:` which can't be used as file names.

This pull request uses the pipeline name instead of the pipeline display name for naming the log file.